### PR TITLE
move mapbox default public key to env var

### DIFF
--- a/packages/nextjs/components/Mapbox.js
+++ b/packages/nextjs/components/Mapbox.js
@@ -4,7 +4,7 @@ import mapboxgl from "!mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import randomMapLoad from "~~/utils/randomizeMapboxLoad";
 
-mapboxgl.accessToken = "pk.eyJ1Ijoicm9uY2h1Y2siLCJhIjoiY2x2Y2o5Z2drMGY3cjJrcGI4b2xsNzdtaCJ9.gi5RJ8qRhTSwfYuhVwhmvQ";
+mapboxgl.accessToken = process.env.NEXT_MAPBOX_DEFAULT_ACCESS_TOKEN | "";
 
 export default function Mapbox({
   setIsControlsActive = bool => bool,


### PR DESCRIPTION
## Description
- [x] Moved mapbox key to  `NEXT_MAPBOX_DEFAULT_ACCESS_TOKEN` 
- [x] updated Vercel with env vars on all environments. 
<img width="937" alt="Screen Shot 2024-07-14 at 13 39 51" src="https://github.com/user-attachments/assets/b8fe96df-30fd-49e2-adf4-6b19767bd442">

https://vercel.com/astralprotocol/logbook/settings/environment-variables